### PR TITLE
Only run CLI when executing as script

### DIFF
--- a/dist/cli/index.d.ts
+++ b/dist/cli/index.d.ts
@@ -1,3 +1,4 @@
+import * as yargs from 'yargs';
 export declare function compose(builder: any, ...otherBuilders: any[]): any;
-export declare const build: (args: any) => any;
-export declare const argv: any;
+export declare const buildMain: (args: yargs.Argv) => yargs.Argv;
+export declare const build: any;

--- a/dist/cli/index.js
+++ b/dist/cli/index.js
@@ -1,6 +1,5 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-const yargs = require("yargs");
 const typescript_1 = require("./typescript");
 const jsonld_1 = require("./jsonld");
 const Package = require('../../package');
@@ -11,7 +10,7 @@ function compose(builder, ...otherBuilders) {
     return (...args) => otherBuilder(builder(...args));
 }
 exports.compose = compose;
-exports.build = args => args
+exports.buildMain = (args) => args
     .usage('Usage: $0 <command> [options] <pattern>')
     .version(Package.version)
     .alias('v', 'version')
@@ -22,4 +21,4 @@ exports.build = args => args
     .alias('h', 'help')
     .epilog('Happy coding!')
     .wrap(100);
-exports.argv = compose(exports.build, typescript_1.builder, jsonld_1.builder)(yargs).argv;
+exports.build = compose(exports.buildMain, typescript_1.builder, jsonld_1.builder);

--- a/dist/cli/jsonld.d.ts
+++ b/dist/cli/jsonld.d.ts
@@ -1,2 +1,3 @@
+import * as yargs from 'yargs';
 export declare function handleJSONLD(argv: any): Promise<void>;
-export declare const builder: (args: any) => any;
+export declare const builder: (args: yargs.Argv) => yargs.Argv;

--- a/dist/cli/jsonld.js
+++ b/dist/cli/jsonld.js
@@ -18,7 +18,7 @@ function handleJSONLD(argv) {
     });
 }
 exports.handleJSONLD = handleJSONLD;
-exports.builder = args => args.command(['jsonld [options] <pattern>', 'ld'], 'generate JSON-LD from RDF', (args) => {
+exports.builder = (args) => args.command(['jsonld [options] <pattern>', 'ld'], 'generate JSON-LD from RDF', (args) => {
     return args
         .option('c', {
         desc: 'output context',

--- a/dist/cli/typescript.d.ts
+++ b/dist/cli/typescript.d.ts
@@ -1,2 +1,3 @@
+import * as yargs from 'yargs';
 export declare function handleTypescript(argv: any): Promise<void>;
-export declare const builder: (args: any) => any;
+export declare const builder: (args: yargs.Argv) => yargs.Argv;

--- a/dist/cli/typescript.js
+++ b/dist/cli/typescript.js
@@ -18,7 +18,7 @@ function handleTypescript(argv) {
     });
 }
 exports.handleTypescript = handleTypescript;
-exports.builder = args => args.command(['typescript [options] <pattern>', 'ts'], 'generate TypeScript from RDF', (args) => {
+exports.builder = (args) => args.command(['typescript [options] <pattern>', 'ts'], 'generate TypeScript from RDF', (args) => {
     return args
         .option('p', {
         desc: 'output prefixes',

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,12 @@ function __export(m) {
     for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-const Package = require('../package');
+const yargs = require("yargs");
+const cli_1 = require("./cli");
+if (require.main === module) {
+    console.log('Running as script.');
+    cli_1.build(yargs).argv;
+}
 __export(require("./cli"));
 __export(require("./helpers"));
 __export(require("./model"));

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,5 +1,4 @@
 import * as yargs from 'yargs';
-
 import { builder as buildTS } from './typescript';
 import { builder as buildLD } from './jsonld';
 
@@ -28,7 +27,7 @@ export function compose(builder, ...otherBuilders) {
 //   process.exit(1);
 // }
 
-export const build = args => args
+export const buildMain = (args: typeof yargs) => args
     .usage('Usage: $0 <command> [options] <pattern>')
     .version(Package.version)
     .alias('v', 'version')
@@ -41,4 +40,4 @@ export const build = args => args
     .wrap(100);
     // .fail(handleError)
 
-export const argv = compose(build, buildTS, buildLD)(yargs).argv;
+export const build = compose(buildMain, buildTS, buildLD);

--- a/src/cli/jsonld.ts
+++ b/src/cli/jsonld.ts
@@ -11,7 +11,7 @@ export async function handleJSONLD(argv) {
   console.log(output);
 }
 
-export const builder = args => args.command([ 'jsonld [options] <pattern>', 'ld' ], 'generate JSON-LD from RDF', (args) => {
+export const builder = (args: typeof yargs) => args.command([ 'jsonld [options] <pattern>', 'ld' ], 'generate JSON-LD from RDF', (args) => {
   return args
     .option('c', {
       desc: 'output context',

--- a/src/cli/typescript.ts
+++ b/src/cli/typescript.ts
@@ -11,7 +11,7 @@ export async function handleTypescript(argv) {
   console.log(output);
 }
 
-export const builder = args => args.command([ 'typescript [options] <pattern>', 'ts' ], 'generate TypeScript from RDF', (args) => {
+export const builder = (args: typeof yargs) => args.command([ 'typescript [options] <pattern>', 'ts' ], 'generate TypeScript from RDF', (args) => {
   return args
     .option('p', {
       desc: 'output prefixes',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,14 @@
 #!/usr/bin/env node
+import * as yargs from 'yargs';
+import { build } from './cli';
 
-import * as Model from './model';
-import * as Helpers from './helpers';
-import * as TS from './typescript';
+declare const require: any;
+if (require.main === module) {
+  console.log('Running as script.');
 
-const Package = require('../package');
-//
-// declare const require: any;
-// if (require.main === module) {
-//
-//   global["Knowledge"] = module.exports;
-// }
+  // This actually initializes the CLI. Doing '.argv' is also needed 
+  build(yargs).argv;
+}
 
 export * from './cli';
 


### PR DESCRIPTION
This PR fixes the behaviour of the package when being imported as a library. Rather than attempting to run the CLI and exiting the process, the package will opt to not load the CLI if it is not being executed as a script, allowing the package to be used both as a CLI as well as a library.