### PR TITLE
Track if properties map to native types and apply in context generation

### DIFF
--- a/dist/jsonld/context.js
+++ b/dist/jsonld/context.js
@@ -5,11 +5,9 @@ function classToContextByPrefix(classObj) {
     const contextsByPrefix = classObj.properties.reduce((memo, property) => {
         const prefix = semtools.getNamespace(property.iri);
         const name = semtools.getLocalName(property.iri);
-        const context = property.isFunctional ? property.iri : {
-            "@id": property.iri,
-            "@type": "@id",
-            "@container": "@set"
-        };
+        const context = property.isNative ?
+            (property.isFunctional ? property.iri : { "@id": property.iri, "@container": "@set" }) :
+            (property.isFunctional ? { "@id": property.iri, "@type": "@id" } : { "@id": property.iri, "@type": "@id", "@container": "@set" });
         if (prefix in memo)
             memo[prefix][name] = context;
         else

--- a/dist/model/classes.d.ts
+++ b/dist/model/classes.d.ts
@@ -2,6 +2,7 @@ export declare type Property = {
     iri: string;
     range: string[];
     isFunctional: boolean;
+    isNative: boolean;
 };
 export declare type Class = {
     iri: string;
@@ -9,6 +10,20 @@ export declare type Class = {
     subClasses: Array<string>;
     properties: Array<Property>;
 };
+export declare const nativeTypeMap: {
+    boolean: {
+        'http://www.w3.org/2001/XMLSchema#boolean': boolean;
+    };
+    string: {
+        'http://www.w3.org/2001/XMLSchema#string': boolean;
+        'http://www.w3.org/2001/XMLSchema#duration': boolean;
+    };
+    number: {
+        'http://www.w3.org/2001/XMLSchema#integer': boolean;
+        'http://www.w3.org/2001/XMLSchema#decimal': boolean;
+    };
+};
+export declare function isNativeType(iris: string[]): boolean;
 export declare function expandProperty(graph: any, iri: string): Object;
 export declare function expandClass(graph: any, iri: string): Object;
 export declare function getClasses(ontology: any): Promise<{

--- a/dist/model/classes.js
+++ b/dist/model/classes.js
@@ -10,13 +10,34 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const semtools = require('semantic-toolkit');
 const Helpers = require("../helpers");
+exports.nativeTypeMap = {
+    boolean: {
+        'http://www.w3.org/2001/XMLSchema#boolean': true,
+    },
+    string: {
+        'http://www.w3.org/2001/XMLSchema#string': true,
+        'http://www.w3.org/2001/XMLSchema#duration': true,
+    },
+    number: {
+        'http://www.w3.org/2001/XMLSchema#integer': true,
+        'http://www.w3.org/2001/XMLSchema#decimal': true,
+    },
+};
+function isNativeType(iris) {
+    return Object.keys(exports.nativeTypeMap).reduce((memo, key) => {
+        return memo || iris.reduce((memo, iri) => iri in exports.nativeTypeMap[key], memo);
+    }, false);
+}
+exports.isNativeType = isNativeType;
 function expandProperty(graph, iri) {
     const range = graph.match(iri, 'http://www.w3.org/2000/01/rdf-schema#range', null).map(t => t.object);
     const isFunctional = graph.match(iri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2002/07/owl#FunctionalProperty').length > 0;
+    const isNative = isNativeType(range);
     return {
         iri,
         range,
-        isFunctional
+        isFunctional,
+        isNative
     };
 }
 exports.expandProperty = expandProperty;

--- a/dist/typescript/index.d.ts
+++ b/dist/typescript/index.d.ts
@@ -1,13 +1,3 @@
-export declare const nativeTypeMap: {
-    boolean: {};
-    string: {
-        'http://www.w3.org/2001/XMLSchema#duration': boolean;
-    };
-    number: {
-        'http://www.w3.org/2001/XMLSchema#integer': boolean;
-        'http://www.w3.org/2001/XMLSchema#decimal': boolean;
-    };
-};
 export declare function typeForIris(iris: string[]): string;
 export declare function objectToTSModule(obj: any): string;
 export declare function prefixesToTS({prefixes}: {

--- a/dist/typescript/index.js
+++ b/dist/typescript/index.js
@@ -4,16 +4,6 @@ function __export(m) {
 }
 Object.defineProperty(exports, "__esModule", { value: true });
 const semtools = require('semantic-toolkit');
-exports.nativeTypeMap = {
-    boolean: {},
-    string: {
-        'http://www.w3.org/2001/XMLSchema#duration': true,
-    },
-    number: {
-        'http://www.w3.org/2001/XMLSchema#integer': true,
-        'http://www.w3.org/2001/XMLSchema#decimal': true,
-    },
-};
 function typeForIris(iris) {
     if (iris.length === 0)
         throw new Error('No type for empty iris.');

--- a/dist/typescript/type-guards.js
+++ b/dist/typescript/type-guards.js
@@ -2,9 +2,10 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const semtools = require('semantic-toolkit');
 const _1 = require(".");
+const model_1 = require("../model");
 function nativeTypesToTypeGuardTS() {
-    return Object.keys(_1.nativeTypeMap).map(nativeType => {
-        const iris = Object.keys(_1.nativeTypeMap[nativeType]);
+    return Object.keys(model_1.nativeTypeMap).map(nativeType => {
+        const iris = Object.keys(model_1.nativeTypeMap[nativeType]);
         return iris.map(iri => {
             const typeName = _1.typeForIris([iri]);
             const typeGuardName = getTypeGuardName(typeName);
@@ -31,7 +32,7 @@ function propertyToPredicate(propertyObj, options) {
     const name = semtools.getLocalName(propertyObj.iri);
     const type = _1.typeForIris(propertyObj.range);
     const isSingular = propertyObj.isFunctional;
-    const isNativetype = type in _1.nativeTypeMap;
+    const isNativetype = type in model_1.nativeTypeMap;
     const keyCheck = `"${name}" in obj`;
     const undefinedCheck = `obj["${name}"] !== undefined`;
     const nullCheck = `obj["${name}"] !== null`;

--- a/dist/typescript/types.js
+++ b/dist/typescript/types.js
@@ -2,10 +2,16 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const semtools = require('semantic-toolkit');
 const _1 = require(".");
+const model_1 = require("../model");
 function nativeTypesToTS() {
-    return Object.keys(_1.nativeTypeMap).map(nativeType => {
-        const iris = Object.keys(_1.nativeTypeMap[nativeType]);
-        return iris.map(iri => `export type ${_1.typeForIris([iri])} = ${nativeType};`).join('\n');
+    return Object.keys(model_1.nativeTypeMap).map(nativeType => {
+        const iris = Object.keys(model_1.nativeTypeMap[nativeType]);
+        return iris.map(iri => {
+            const aliasType = _1.typeForIris([iri]);
+            if (nativeType === aliasType)
+                return '';
+            return `export type ${aliasType} = ${nativeType};`;
+        }).join('\n');
     }).join('\n');
 }
 exports.nativeTypesToTS = nativeTypesToTS;

--- a/src/jsonld/context.ts
+++ b/src/jsonld/context.ts
@@ -5,11 +5,11 @@ export function classToContextByPrefix(classObj: Class) {
   const contextsByPrefix = classObj.properties.reduce((memo, property) => {
     const prefix = semtools.getNamespace(property.iri);
     const name = semtools.getLocalName(property.iri);
-    const context = property.isFunctional ? property.iri : {
-      "@id": property.iri,
-      "@type": "@id",
-      "@container": "@set"
-    };
+
+    // console.log(`Property ${property.iri} is native? `, property.isNative);
+    const context = property.isNative ?
+      (property.isFunctional ? property.iri : { "@id": property.iri, "@container": "@set" }) :
+      (property.isFunctional ? { "@id": property.iri, "@type": "@id" } : { "@id": property.iri, "@type": "@id", "@container": "@set" });
 
     if (prefix in memo) memo[prefix][name] = context;
     else memo[prefix] = { [name]: context };

--- a/src/model/classes.ts
+++ b/src/model/classes.ts
@@ -6,6 +6,7 @@ export type Property = {
   iri: string,
   range: string[],
   isFunctional: boolean
+  isNative: boolean
 }
 
 export type Class = {
@@ -15,14 +16,37 @@ export type Class = {
   properties: Array<Property>
 }
 
+export const nativeTypeMap = {
+  boolean: {
+    'http://www.w3.org/2001/XMLSchema#boolean': true,
+  },
+  string: {
+    'http://www.w3.org/2001/XMLSchema#string': true,
+    'http://www.w3.org/2001/XMLSchema#duration': true,
+  },
+  number: {
+    'http://www.w3.org/2001/XMLSchema#integer': true,
+    'http://www.w3.org/2001/XMLSchema#decimal': true,
+  },
+};
+
+export function isNativeType(iris: string[]): boolean {
+  // console.log(`Is native?`, iris);
+  return Object.keys(nativeTypeMap).reduce((memo, key) => {
+    return memo || iris.reduce((memo, iri) => iri in nativeTypeMap[key], memo);
+  }, false);
+}
 
 export function expandProperty(graph, iri: string): Object {
   const range = graph.match(iri, 'http://www.w3.org/2000/01/rdf-schema#range', null).map(t => t.object);
   const isFunctional = graph.match(iri, 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type','http://www.w3.org/2002/07/owl#FunctionalProperty').length > 0;
+  const isNative = isNativeType(range);
+
   return {
     iri,
     range,
-    isFunctional
+    isFunctional,
+    isNative
   };
 }
 

--- a/src/typescript/index.ts
+++ b/src/typescript/index.ts
@@ -1,18 +1,6 @@
-const semtools = require('semantic-toolkit');
+import { nativeTypeMap } from '../model';
 
-export const nativeTypeMap = {
-  boolean: {
-    // 'http://www.w3.org/2001/XMLSchema#boolean': true,
-  },
-  string: {
-    // 'http://www.w3.org/2001/XMLSchema#string': true,
-    'http://www.w3.org/2001/XMLSchema#duration': true,
-  },
-  number: {
-    'http://www.w3.org/2001/XMLSchema#integer': true,
-    'http://www.w3.org/2001/XMLSchema#decimal': true,
-  },
-};
+const semtools = require('semantic-toolkit');
 
 export function typeForIris(iris: string[]): string {
   if (iris.length === 0) throw new Error('No type for empty iris.');

--- a/src/typescript/type-guards.ts
+++ b/src/typescript/type-guards.ts
@@ -1,7 +1,7 @@
 const semtools = require('semantic-toolkit');
-import { typeForIris, nativeTypeMap } from '.';
+import { typeForIris } from '.';
 
-import { Property, Class } from '../model';
+import { Property, Class, nativeTypeMap } from '../model';
 
 export function nativeTypesToTypeGuardTS() {
   return Object.keys(nativeTypeMap).map(nativeType => {

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -1,12 +1,17 @@
 const semtools = require('semantic-toolkit');
-import { typeForIris, nativeTypeMap } from '.';
+import { typeForIris } from '.';
 
-import { Property, Class } from '../model';
+import { Property, Class, nativeTypeMap } from '../model';
 
 export function nativeTypesToTS() {
   return Object.keys(nativeTypeMap).map(nativeType => {
     const iris = Object.keys(nativeTypeMap[nativeType]);
-    return iris.map(iri => `export type ${typeForIris([ iri ])} = ${nativeType};`).join('\n')
+    return iris.map(iri => {
+      const aliasType = typeForIris([ iri ]);
+      // Skip when aliasing types to themselves
+      if (nativeType === aliasType) return '';
+      return `export type ${aliasType} = ${nativeType};`
+    }).join('\n')
   }).join('\n');
 }
 


### PR DESCRIPTION
This PR adds `isNative` to the `Property` type, allowing the JSON-LD context to encode arrays of both native things and IRIs properly.