### PR TITLE
Add RDF.Resource, extend and alias

### DIFF
--- a/dist/typescript/types.d.ts
+++ b/dist/typescript/types.d.ts
@@ -2,6 +2,11 @@ import { Property, Class } from '../model';
 export declare function nativeTypesToTS(): string;
 export declare function propertyToTS(propertyObj: Property): string;
 export declare function classToTS(classObj: Class, classIris: string[]): string;
+export declare function rdfResourceToTS(): string;
+export declare function classToTSAliases(classObj: Class, classIris: string[]): string[];
+export declare function aliasRDFResources(classesObj: {
+    classes: Class[];
+}): string;
 export declare function classesToTS(classesObj: {
     classes: Class[];
 }): string;

--- a/src/typescript/types.ts
+++ b/src/typescript/types.ts
@@ -26,7 +26,7 @@ export function propertyToTS(propertyObj: Property): string {
 export function classToTS(classObj: Class, classIris: string[]): string {
   const name = semtools.getLocalName(classObj.iri);
   const existingSuperClasses = classObj.superClasses.filter(c => classIris.indexOf(c) != -1);
-  const superTypes = existingSuperClasses.length === 0 ? '' : `${typeForIris(existingSuperClasses)} &`;
+  const superTypes = existingSuperClasses.length === 0 ? 'RDF.Resource &' : `${typeForIris(existingSuperClasses)} &`;
 
   return `export type ${name} = ${superTypes} {
     ${classObj.properties.map(propertyToTS).join('\n')}
@@ -34,8 +34,39 @@ export function classToTS(classObj: Class, classIris: string[]): string {
   `;
 }
 
+export function rdfResourceToTS() {
+  return `export module RDF {
+    export type Resource = {
+      id: string
+    };
+  };`;
+}
+
+export function classToTSAliases(classObj: Class, classIris: string[]): string[] {
+  const name = semtools.getLocalName(classObj.iri);
+  const propertyRanges = classObj.properties.reduce((memo, property) => [ ...memo, ...(property.isNative ? [] : property.range) ], []);
+  const nonExistingPropertyClasses = propertyRanges.filter(c => classIris.indexOf(c) == -1);
+  const nonExistingSuperClasses = classObj.superClasses.filter(c => classIris.indexOf(c) == -1);
+  const nonExistingClasses = Object.keys([ ...nonExistingPropertyClasses, ...nonExistingSuperClasses ].reduce((memo, key) => ({ ...memo, [key]: true }), {}));
+  // console.log(nonExistingClasses);
+  return nonExistingClasses;
+}
+
+export function aliasRDFResources(classesObj: { classes: Class[] }): string {
+  const iris = classesObj.classes.map(c => c.iri);
+  const rdfTS = rdfResourceToTS();
+  const nonExistingClasses = Object.keys(classesObj.classes.reduce((memo, c) => [ ...memo, ...classToTSAliases(c, iris) ], []).reduce((memo, key) => ({ ...memo, [key]: true }), {}));
+  const aliasesTS = nonExistingClasses.map(iri => {
+    const aliasType = typeForIris([ iri ]);
+    return `export type ${aliasType} = RDF.Resource;`;
+  }).join('\n');
+
+  return rdfTS + '\n' + aliasesTS;
+}
+
 export function classesToTS(classesObj: { classes: Class[] }): string {
   const nativeTypeTS = nativeTypesToTS();
+  const aliasesTS = aliasRDFResources(classesObj);
   const iris = classesObj.classes.map(c => c.iri);
-  return nativeTypeTS + '\n' + classesObj.classes.map(c => classToTS(c, iris)).join('\n');
+  return nativeTypeTS + '\n' + aliasesTS + '\n' + classesObj.classes.map(c => classToTS(c, iris)).join('\n');
 }


### PR DESCRIPTION
This PR adds `RDF.Resource` as a base class (with only an `id` property of type `string`. It also extends top-level types via union and is used to alias all other undefined types for classes.